### PR TITLE
notifier: add delivered_total metric for successful alert deliveries

### DIFF
--- a/notifier/manager.go
+++ b/notifier/manager.go
@@ -283,7 +283,9 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 func (n *Manager) sendOneBatch() {
 	alerts := n.nextBatch()
 
-	if !n.sendAll(alerts...) {
+	if n.sendAll(alerts...) {
+		n.metrics.delivered.Add(float64(len(alerts)))
+	} else {
 		n.metrics.dropped.Add(float64(len(alerts)))
 	}
 }

--- a/notifier/metric.go
+++ b/notifier/metric.go
@@ -19,6 +19,7 @@ type alertMetrics struct {
 	latency                 *prometheus.SummaryVec
 	errors                  *prometheus.CounterVec
 	sent                    *prometheus.CounterVec
+	delivered               prometheus.Counter
 	dropped                 prometheus.Counter
 	queueLength             prometheus.GaugeFunc
 	queueCapacity           prometheus.Gauge
@@ -52,6 +53,12 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 		},
 			[]string{alertmanagerLabel},
 		),
+		delivered: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "delivered_total",
+			Help:      "Total number of alerts successfully delivered to at least one Alertmanager.",
+		}),
 		dropped: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -83,6 +90,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 			m.latency,
 			m.errors,
 			m.sent,
+			m.delivered,
 			m.dropped,
 			m.queueLength,
 			m.queueCapacity,


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
N/A

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] notifier: Add prometheus_notifications_delivered_total metric to track alerts successfully delivered to at least one Alertmanager.
```

## Summary

This PR introduces a new `prometheus_notifications_delivered_total` counter metric that tracks alerts successfully delivered to at least one Alertmanager. This enhances observability by providing clear visibility into actual successful deliveries, complementing the existing metrics:

- `prometheus_notifications_sent_total` - tracks all send attempts per Alertmanager
- `prometheus_notifications_dropped_total` - tracks batches that failed completely  
- `prometheus_notifications_errors_total` - tracks per-Alertmanager failures

## Implementation Details

- Added `delivered` counter field to `alertMetrics` struct
- Metric is incremented when `sendAll()` returns `true` (indicating at least one Alertmanager in each configured set received the alerts)
- Follows existing metric naming conventions with namespace `prometheus` and subsystem `notifications`
- Registered with Prometheus registry alongside other notification metrics

## Use Case

This metric enables monitoring of alert delivery success rates and helps distinguish between:
- Alerts that were attempted to be sent (`sent_total`)  
- Alerts that actually reached their destination (`delivered_total`)
- Alerts that completely failed to reach any Alertmanager (`dropped_total`)

This is particularly valuable in multi-Alertmanager deployments where partial failures can occur.